### PR TITLE
Fix null inner exception when retrying on WebException

### DIFF
--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandler.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandler.cs
@@ -118,7 +118,10 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 			if (pingRetryRequest != null) return pingRetryRequest;
 
 			var streamResponse = this.DoElasticsearchCall(requestState);
-			
+
+			if (streamResponse.OriginalException != null)
+				requestState.SeenExceptions.Add(streamResponse.OriginalException);
+
 			aliveResponse = streamResponse.SuccessOrKnownError;
 
 			if (!this.DoneProcessing(streamResponse, requestState, maxRetries, retried)) 

--- a/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerAsync.cs
+++ b/src/Elasticsearch.Net/Connection/RequestHandlers/RequestHandlerAsync.cs
@@ -188,7 +188,12 @@ namespace Elasticsearch.Net.Connection.RequestHandlers
 			{
 				requestState.SeenExceptions.Add(t.Exception);
 			}
+
 			var streamResponse = !t.IsFaulted ? t.Result : null;
+
+			if (streamResponse != null && streamResponse.OriginalException != null)
+				requestState.SeenExceptions.Add(streamResponse.OriginalException);
+
 			//var streamResponse = t.Result;
 			// Audit the call into connection straight away
 			rq.Finish(streamResponse != null && streamResponse.Success, streamResponse == null ? -1 : streamResponse.HttpStatusCode);


### PR DESCRIPTION
When using connection pooling (and retrying), `WebException`s fall out of the normal exception handling in `RequestHandler` and weren't being added to `SeenExceptions`, ultimately causing `MaxRetryException.InnerException` to be null.

Closes #1176