### PR TITLE
Feature/gitlink

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -7,12 +7,12 @@ if not exist build\tools\nuget\nuget.exe (
 )
 
 REM we need FAKE to process our build scripts
-if not exist build\tools\gitlink\lib\net45\gitlink.exe (
+if not exist build\tools\FAKE\tools\Fake.exe (
     ECHO FAKE not found.. Installing..
     "build\tools\nuget\nuget.exe" "install" "FAKE" "-OutputDirectory" "build\tools" "-ExcludeVersion" "-Prerelease"
 )
 
-if not exist build\tools\Node.js\node.exe (
+if not exist build\tools\gitlink\lib\net45\gitlink.exe (
     ECHO Local node not found.. Installing..
     "build\tools\nuget\nuget.exe" "install" "gitlink" "-OutputDirectory" "build\tools" "-ExcludeVersion" "-Prerelease"
 )

--- a/build.bat
+++ b/build.bat
@@ -7,12 +7,15 @@ if not exist build\tools\nuget\nuget.exe (
 )
 
 REM we need FAKE to process our build scripts
-if not exist build\tools\FAKE\tools\Fake.exe (
+if not exist build\tools\gitlink\lib\net45\gitlink.exe (
     ECHO FAKE not found.. Installing..
     "build\tools\nuget\nuget.exe" "install" "FAKE" "-OutputDirectory" "build\tools" "-ExcludeVersion" "-Prerelease"
 )
 
-"build\tools\nuget\nuget.exe" "install" "gitlink" "-OutputDirectory" "build\tools" "-ExcludeVersion" "-Prerelease"
+if not exist build\tools\Node.js\node.exe (
+    ECHO Local node not found.. Installing..
+    "build\tools\nuget\nuget.exe" "install" "gitlink" "-OutputDirectory" "build\tools" "-ExcludeVersion" "-Prerelease"
+)
 
 REM we need nunit-console to run our tests
 if not exist build\tools\NUnit.Runners\tools\nunit-console.exe (

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -22,9 +22,8 @@ Target "Clean" (fun _ ->
 
 let gitLink = fun _ ->
     let exe = "build/tools/gitlink/lib/net45/GitLink.exe"
-    let command = if isMono then (sprintf "mono %s" exe) else exe
     ExecProcess(fun p ->
-      p.FileName <- command
+      p.FileName <- exe
       p.Arguments <- sprintf @". -u https://github.com/elasticsearch/elasticsearch-net -b develop" 
     ) (TimeSpan.FromMinutes 5.0) |> ignore
  

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -23,10 +23,9 @@ Target "Clean" (fun _ ->
 let gitLink = fun _ ->
     let exe = "build/tools/gitlink/lib/net45/GitLink.exe"
     let command = if isMono then (sprintf "mono %s" exe) else exe
-    let branch = if isMono then "develop" else "develop"
     ExecProcess(fun p ->
       p.FileName <- command
-      p.Arguments <- sprintf @". -u https://github.com/elasticsearch/elasticsearch-net -b %s" branch
+      p.Arguments <- sprintf @". -u https://github.com/elasticsearch/elasticsearch-net -b develop" 
     ) (TimeSpan.FromMinutes 5.0) |> ignore
  
 Target "BuildApp" (fun _ ->

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -42,14 +42,14 @@ Target "BuildApp" (fun _ ->
     ]
 
     MSBuild null "Rebuild" msbuildProperties (seq { yield "src/Elasticsearch.sln" }) 
-    gitLink()
+    if not isMono then gitLink()
 
     //moves all the release builds to build/output/PROJECTNAME
     !! "src/**/*.csproj"
       |> Seq.map(fun f -> (f, buildDir + directoryInfo(f).Name.Replace(".csproj", "")))
       |> Seq.iter(fun (f,d) -> 
         CreateDir d
-        CopyDir d (directoryInfo(f).Parent.FullName + @"\bin\Release") allFiles
+        CopyDir d (directoryInfo(f).Parent.FullName + @"/bin/Release") allFiles
       )
     
     //Scan for xml docs and patch them to replace <inheritdoc /> with the documentation

--- a/build/build.fsx
+++ b/build/build.fsx
@@ -20,6 +20,15 @@ Target "Clean" (fun _ ->
     CleanDir buildDir
 )
 
+let gitLink = fun _ ->
+    let exe = "build/tools/gitlink/lib/net45/GitLink.exe"
+    let command = if isMono then (sprintf "mono %s" exe) else exe
+    let branch = if isMono then "develop" else "develop"
+    ExecProcess(fun p ->
+      p.FileName <- command
+      p.Arguments <- sprintf @". -u https://github.com/elasticsearch/elasticsearch-net -b %s" branch
+    ) (TimeSpan.FromMinutes 5.0) |> ignore
+ 
 Target "BuildApp" (fun _ ->
     let binDirs = !! "src/**/bin/**"
                   |> Seq.map DirectoryName
@@ -34,10 +43,16 @@ Target "BuildApp" (fun _ ->
       ("PreBuildEvent","echo"); 
     ]
 
-    //Compile each csproj and output it seperately in build/output/PROJECTNAME
+    MSBuild null "Rebuild" msbuildProperties (seq { yield "src/Elasticsearch.sln" }) 
+    gitLink()
+
+    //moves all the release builds to build/output/PROJECTNAME
     !! "src/**/*.csproj"
       |> Seq.map(fun f -> (f, buildDir + directoryInfo(f).Name.Replace(".csproj", "")))
-      |> Seq.iter(fun (f,d) -> MSBuild d "Build" msbuildProperties (seq { yield f }) |> ignore)
+      |> Seq.iter(fun (f,d) -> 
+        CreateDir d
+        CopyDir d (directoryInfo(f).Parent.FullName + @"\bin\Release") allFiles
+      )
     
     //Scan for xml docs and patch them to replace <inheritdoc /> with the documentation
     //from their interfaces


### PR DESCRIPTION
Updated the build to patch the pdb files using [gitlink](https://github.com/CatenaLogic/GitLink). 

We now msbuild the sln file and manually move `bin\Release\*` instead of building individual projects with `OutputPath` specified.

You will have to to enable source servers:
![Enabling source server support](https://github.com/CatenaLogic/GitLink/raw/develop/doc/images/visualstudio_enablesourceserversupport.png) 

and specify a place for the source to be downloaded:
![Enabling source server support](https://github.com/CatenaLogic/GitLink/raw/develop/doc/images/visualstudio_symbolslocation.png)

Visual studio will now download the source files from raw.github.com automatically while debugging!