### PR TITLE
Fix/nomatch indices dsl

### DIFF
--- a/src/Nest/DSL/Filter/FilterContainer.cs
+++ b/src/Nest/DSL/Filter/FilterContainer.cs
@@ -56,6 +56,8 @@ namespace Nest
 
 		ITypeFilter IFilterContainer.Type { get; set; }
 
+		IIndicesFilter IFilterContainer.Indices { get; set; }
+
 		IMatchAllFilter IFilterContainer.MatchAll { get; set; }
 
 		IHasChildFilter IFilterContainer.HasChild { get; set; }

--- a/src/Nest/DSL/Filter/FilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/FilterDescriptor.cs
@@ -606,6 +606,34 @@ namespace Nest
 			filter.Value = type;
 			return  this.New(filter, f => f.Type = filter);
 		}
+		
+		/// <summary>
+		/// The indices filter can be used when executed across multiple indices, allowing to have a 
+		/// filter that executes only when executed on an index that matches a specific list of indices, 
+		/// and another filter that executes when it is executed on an index that does not match the listed indices.
+		/// </summary>
+		public FilterContainer Indices<K>(Action<IndicesFilterDescriptor<K>> filterSelector) where K : class
+		{
+			var filter = new IndicesFilterDescriptor<K>();
+			if (filterSelector != null)
+				filterSelector(filter);
+
+			return this.New(filter, f => f.Indices = filter);
+		}
+
+		/// <summary>
+		/// The indices filter can be used when executed across multiple indices, allowing to have a 
+		/// filter that executes only when executed on an index that matches a specific list of indices, 
+		/// and another filter that executes when it is executed on an index that does not match the listed indices.
+		/// </summary>
+		public FilterContainer Indices(Action<IndicesFilterDescriptor<T>> filterSelector) 
+		{
+			var filter = new IndicesFilterDescriptor<T>();
+			if (filterSelector != null)
+				filterSelector(filter);
+
+			return this.New(filter, f => f.Indices = filter);
+		}
 
 		/// <summary>
 		/// Filters documents matching the provided document / mapping type. 

--- a/src/Nest/DSL/Filter/IFilterContainer.cs
+++ b/src/Nest/DSL/Filter/IFilterContainer.cs
@@ -69,6 +69,9 @@ namespace Nest
 		[JsonProperty(PropertyName = "limit")]
 		ILimitFilter Limit { get; set; }
 
+		[JsonProperty(PropertyName = "indices")]
+		IIndicesFilter Indices { get; set; }
+
 		[JsonProperty(PropertyName = "type")]
 		ITypeFilter Type { get; set; }
 

--- a/src/Nest/DSL/Filter/IndicesFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/IndicesFilterDescriptor.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+
+namespace Nest
+{
+	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
+	[JsonConverter(typeof(ReadAsTypeConverter<IndicesFilterDescriptor<object>>))]
+	public interface IIndicesFilter : IFilter
+	{
+		[JsonProperty("indices")]
+		IEnumerable<string> Indices { get; set; }
+
+		[JsonProperty("filter")]
+		[JsonConverter(typeof(CompositeJsonConverter<ReadAsTypeConverter<FilterDescriptor<object>>, CustomJsonConverter>))]
+		IFilterContainer Filter { get; set; }
+
+		[JsonProperty("no_match_filter")]
+		[JsonConverter(typeof(NoMatchFilterConverter))]
+		IFilterContainer NoMatchFilter { get; set; }
+
+	}
+
+	public class NoMatchFilterConverter : CompositeJsonConverter<ReadAsTypeConverter<FilterDescriptor<object>>, CustomJsonConverter>
+	{
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.String)
+			{
+				var en = serializer.Deserialize<NoMatchShortcut>(reader);
+				return new NoMatchFilterContainer {Shortcut = en};
+			}
+
+			return base.ReadJson(reader, objectType, existingValue, serializer);
+		}
+	}
+
+	public class NoMatchFilterContainer : FilterContainer, ICustomJson
+	{
+		public NoMatchShortcut? Shortcut { get; set; }
+
+		object ICustomJson.GetCustomJson()
+		{
+			if (this.Shortcut.HasValue) return this.Shortcut;
+			var f = ((IFilterContainer)this);
+			if (f.RawFilter.IsNullOrEmpty()) return f;
+			return new RawJson(f.RawFilter);
+		}
+	}
+
+	public class IndicesFilter : PlainFilter, IIndicesFilter
+	{
+		protected internal override void WrapInContainer(IFilterContainer container)
+		{
+			container.Indices = this;
+		}
+
+		bool IFilter.IsConditionless { get { return false; } }
+		public NestedScore? Score { get; set; }
+		public IFilterContainer Filter { get; set; }
+		public IFilterContainer NoMatchFilter { get; set; }
+		public IEnumerable<string> Indices { get; set; }
+	}
+
+	public class IndicesFilterDescriptor<T> : FilterBase, IIndicesFilter where T : class
+	{
+		IFilterContainer IIndicesFilter.Filter { get; set; }
+
+		IFilterContainer IIndicesFilter.NoMatchFilter { get; set; }
+
+		IEnumerable<string> IIndicesFilter.Indices { get; set; }
+
+		bool IFilter.IsConditionless
+		{
+			get
+			{
+				return ((IIndicesFilter)this).NoMatchFilter == null && ((IIndicesFilter)this).Filter == null;
+			}
+		}
+
+		public IndicesFilterDescriptor<T> Filter(Func<FilterDescriptor<T>, FilterContainer> filterSelector)
+		{
+			var qd = new FilterDescriptor<T>();
+			var q = filterSelector(qd);
+			if (q.IsConditionless)
+				return this;
+
+
+			((IIndicesFilter)this).Filter = q;
+			return this;
+		}
+
+		public IndicesFilterDescriptor<T> Filter<K>(Func<FilterDescriptor<K>, FilterContainer> filterSelector) where K : class
+		{
+			var qd = new FilterDescriptor<K>();
+			var q = filterSelector(qd);
+			if (q.IsConditionless)
+				return this;
+
+			((IIndicesFilter)this).Filter = q;
+			return this;
+		}
+
+		public IndicesFilterDescriptor<T> NoMatchFilter(NoMatchShortcut shortcut)
+		{
+			((IIndicesFilter)this).NoMatchFilter = new NoMatchFilterContainer { Shortcut = shortcut };
+			return this;
+		}
+		
+		public IndicesFilterDescriptor<T> NoMatchFilter(Func<FilterDescriptor<T>, FilterContainer> filterSelector)
+		{
+			var qd = new FilterDescriptor<T>();
+			var q = filterSelector(qd);
+			if (q.IsConditionless)
+				return this;
+
+			((IIndicesFilter)this).NoMatchFilter = q;
+			return this;
+		}
+		public IndicesFilterDescriptor<T> NoMatchFilter<K>(Func<FilterDescriptor<K>, IFilterContainer> filterSelector) where K : class
+		{
+			var qd = new FilterDescriptor<K>();
+			var q = filterSelector(qd);
+			if (q.IsConditionless)
+				return this;
+
+			((IIndicesFilter)this).NoMatchFilter = q;
+			return this;
+		}
+		public IndicesFilterDescriptor<T> Indices(IEnumerable<string> indices)
+		{
+			((IIndicesFilter)this).Indices = indices;
+			return this;
+		}
+	}
+}

--- a/src/Nest/DSL/Query/IndicesQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/IndicesQueryDescriptor.cs
@@ -12,6 +12,9 @@ namespace Nest
 	[JsonConverter(typeof(ReadAsTypeConverter<IndicesQueryDescriptor<object>>))]
 	public interface IIndicesQuery : IQuery
 	{
+		[JsonProperty("indices")]
+		IEnumerable<string> Indices { get; set; }
+
 		[JsonProperty("score_mode"), JsonConverter(typeof (StringEnumConverter))]
 		NestedScore? Score { get; set; }
 
@@ -22,9 +25,6 @@ namespace Nest
 		[JsonProperty("no_match_query")]
 		[JsonConverter(typeof(NoMatchQueryConverter))]
 		IQueryContainer NoMatchQuery { get; set; }
-
-		[JsonProperty("indices")]
-		IEnumerable<string> Indices { get; set; }
 	}
 
 	public class NoMatchQueryConverter : CompositeJsonConverter<ReadAsTypeConverter<QueryDescriptor<object>>, CustomJsonConverter>

--- a/src/Nest/DSL/Query/IndicesQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/IndicesQueryDescriptor.cs
@@ -20,10 +20,38 @@ namespace Nest
 		IQueryContainer Query { get; set; }
 
 		[JsonProperty("no_match_query")]
+		[JsonConverter(typeof(NoMatchQueryConverter))]
 		IQueryContainer NoMatchQuery { get; set; }
 
 		[JsonProperty("indices")]
 		IEnumerable<string> Indices { get; set; }
+	}
+
+	public class NoMatchQueryConverter : CompositeJsonConverter<ReadAsTypeConverter<QueryDescriptor<object>>, CustomJsonConverter>
+	{
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			if (reader.TokenType == JsonToken.String)
+			{
+				var en = serializer.Deserialize<NoMatchShortcut>(reader);
+				return new NoMatchQueryContainer {Shortcut = en};
+			}
+
+			return base.ReadJson(reader, objectType, existingValue, serializer);
+		}
+	}
+
+	public class NoMatchQueryContainer : QueryContainer, ICustomJson
+	{
+		public NoMatchShortcut? Shortcut { get; set; }
+
+		object ICustomJson.GetCustomJson()
+		{
+			if (this.Shortcut.HasValue) return this.Shortcut;
+			var f = ((IQueryContainer)this);
+			if (f.RawQuery.IsNullOrEmpty()) return f;
+			return new RawJson(f.RawQuery);
+		}
 	}
 
 	public class IndicesQuery : PlainQuery, IIndicesQuery
@@ -81,6 +109,12 @@ namespace Nest
 			return this;
 		}
 		
+		public IndicesQueryDescriptor<T> NoMatchQuery(NoMatchShortcut shortcut)
+		{
+			((IIndicesQuery)this).NoMatchQuery = new NoMatchQueryContainer { Shortcut = shortcut };
+			return this;
+		}
+
 		public IndicesQueryDescriptor<T> NoMatchQuery(Func<QueryDescriptor<T>, QueryContainer> querySelector)
 		{
 			var qd = new QueryDescriptor<T>();

--- a/src/Nest/Domain/DSL/NoMatchShortcut.cs
+++ b/src/Nest/Domain/DSL/NoMatchShortcut.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace Nest
+{
+	[JsonConverter(typeof (StringEnumConverter))]
+	public enum NoMatchShortcut
+	{
+		[EnumMember(Value = "none")] None,
+		[EnumMember(Value = "all")] All
+	}
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -253,6 +253,8 @@
     <Compile Include="DSL\Aggregations\TopHitsAggregationDescriptor.cs" />
     <Compile Include="DSL\Aggregations\GeoBoundsAggregationDescriptor.cs" />
     <Compile Include="DSL\Aggregations\ReverseNestedAggregationDescriptor.cs" />
+    <Compile Include="DSL\Filter\IndicesFilterDescriptor.cs" />
+    <Compile Include="Domain\DSL\NoMatchShortcut.cs" />
     <Compile Include="DSL\UpgradeDescriptor.cs" />
     <Compile Include="DSL\UpgradeStatusDescriptor.cs" />
     <Compile Include="DSL\VerifyRepositoryDescriptor.cs" />

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -402,6 +402,7 @@
     <Compile Include="QueryParsers\Visitor\VisitorDemoUseCase.cs" />
     <Compile Include="QueryParsers\Visitor\VisitorTests.cs" />
     <Compile Include="Reproduce\Reproduce1146Tests.cs" />
+    <Compile Include="Reproduce\Reproduce1187Tests.cs" />
     <Compile Include="Reproduce\Reproduce990Tests.cs" />
     <Compile Include="Reproduce\Reproduce974Tests.cs" />
     <Compile Include="Reproduce\Reproduce928Tests.cs" />
@@ -418,6 +419,7 @@
     <Compile Include="Search\Filter\Modes\ConditionlessFilterJson.cs" />
     <Compile Include="Search\Filter\Modes\FilterModesTests.cs" />
     <Compile Include="Search\Filter\Singles\GeoHashCellFilterJson.cs" />
+    <Compile Include="Search\Filter\Singles\IndicesFilterJson.cs" />
     <Compile Include="Search\Filter\Singles\TermsLookupFilterJson.cs" />
     <Compile Include="Search\Filter\Singles\GeoIndexedShapeFilterJson.cs" />
     <Compile Include="Search\Filter\Singles\GeoShapeFilterJson.cs" />

--- a/src/Tests/Nest.Tests.Unit/Reproduce/Reproduce1187Tests.cs
+++ b/src/Tests/Nest.Tests.Unit/Reproduce/Reproduce1187Tests.cs
@@ -1,0 +1,148 @@
+﻿using System.IO;
+using FluentAssertions;
+using Nest.Tests.MockData.Domain;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Nest.Tests.Unit.Reproduce
+{
+	[TestFixture]
+	public class Reproduce1187Tests : BaseJsonTests
+	{
+		[Test]
+		public void IsClientSideSearchQueryDeserialisable()
+		{
+			var newDescriptor = Deserialize<SearchDescriptor<dynamic>>(original);
+			var actual = Serialize(newDescriptor);//Should is empty
+
+			var descriptorJobject = JObject.Parse(actual);
+			var expressionList = new object[][]
+	                             {
+	                                 new[] {"size"},//Works
+	                                 new[] {"from"},//Works
+	                                 new[] {"query", "filtered", "query", "query_string", "fields"},//Works
+	                                 new[] {"query", "filtered", "filter", "bool", "must"},//Works
+//Can't find contents of should
+                                     new object[] {"query", "filtered", "filter", "bool", "should", 0, "indices", "filter"},
+                                     new object[] {"query", "filtered", "filter", "bool", "should", 0, "indices", "no_match_filter"},
+	                                 new[] {"aggs", "Databases", "terms", "field"},//Works
+	                                 new[] {"aggs", "Year", "terms", "field"}//Works
+	                             };
+			foreach (var e in expressionList)
+				VerifyJsonPath(descriptorJobject, e);
+
+			//If we do a search without the below line
+			//it seems to contect /_all/object/_search instead of /_search
+			newDescriptor.AllTypes().AllIndices();
+		}
+
+		private static void VerifyJsonPath(JToken descriptorJobject, IEnumerable<object> strings)
+		{
+			foreach (var item in strings)
+			{
+				Assert.IsNotNull(descriptorJobject[item], item.ToString());
+				descriptorJobject = descriptorJobject[item];
+				if (item.ToString() == "no_match_filter")
+					descriptorJobject.ToString().Should().Be("none");
+			}
+		}
+
+		public string Serialize<T>(T obj) where T : class
+		{
+			var json = Encoding.UTF8.GetString(_client.Serializer.Serialize(obj));
+			return json;
+		}
+
+		public T Deserialize<T>(string json) where T : class
+		{
+			return _client.Serializer.Deserialize<T>(new MemoryStream(Encoding.UTF8.GetBytes(json)));
+		}
+
+		const string original =
+			@"{
+   ""size"":10,
+   ""from"":0,
+   ""query"":{
+      ""filtered"":{
+         ""query"":{
+            ""query_string"":{
+               ""query"":""*"",
+               ""default_operator"":""AND"",
+               ""fields"":[
+                  ""type1._all"",
+                  ""type2.title"",
+                  ""type3._all"",
+                  ""type4._all""
+               ]
+            }
+         },
+         ""filter"":{
+            ""bool"":{
+               ""must"":[
+
+               ],
+               ""should"":[
+                  {
+                     ""indices"":{
+                        ""index"":""index1"",
+                        ""filter"":{
+                           ""terms"":{
+                              ""_type"":[
+                                 ""type1"",
+                                 ""type2"",
+                                 ""type3""
+                              ]
+                           }
+                        },
+                        ""no_match_filter"":""none""
+                     }
+                  },
+                  {
+                     ""indices"":{
+                        ""index"":""index2"",
+                        ""filter"":{
+                           ""terms"":{
+                              ""_type"":[
+                                 ""type2"",
+                                 ""type4""
+                              ]
+                           }
+                        },
+                        ""no_match_filter"":""none""
+                     }
+                  }
+               ]
+            }
+         }
+      }
+   },
+   ""aggs"":{
+      ""Databases"":{
+         ""terms"":{
+            ""field"":""_type"",
+            ""size"":5
+         }
+      },
+      ""Index"":{
+         ""terms"":{
+            ""field"":""_index"",
+            ""size"":5
+         }
+      },
+      ""Year"":{
+         ""terms"":{
+            ""field"":""publicationYear"",
+            ""size"":5
+         }
+      }
+   }
+}";
+
+	}
+}

--- a/src/Tests/Nest.Tests.Unit/Search/Filter/Singles/IndicesFilterJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Filter/Singles/IndicesFilterJson.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using NUnit.Framework;
+using Nest.Tests.MockData.Domain;
+using NUnit.Framework.Constraints;
+
+namespace Nest.Tests.Unit.Search.Filter.Singles
+{
+	[TestFixture]
+	public class IndicesFilterJson
+	{
+		[Test]
+		public void IndicesFilter()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Filter(filter=>filter
+					.Indices(i=>i
+						.Indices(new [] { "index1", "index2"})
+						.Filter(f=>f.Term(p=>p.Name, "NEST"))
+						.NoMatchFilter(f=>f.Term(p=>p.Name, "Elasticsearch.NET"))
+					)
+				);
+				
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"{
+  from: 0,
+  size: 10,
+  filter: {
+    indices: {
+      indices: [
+        ""index1"",
+        ""index2""
+      ],
+      filter: {
+        term: {
+          name: ""NEST""
+        }
+      },
+      no_match_filter: {
+        term: {
+          name: ""Elasticsearch.NET""
+        }
+      }
+    }
+  }
+}";
+			Assert.True(json.JsonEquals(expected), json);
+		}
+
+		[Test]
+		public void IndicesFilterWithShortcut()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Filter(filter=>filter
+					.Indices(i=>i
+						.Indices(new [] { "index1", "index2"})
+						.Filter(f=>f.Term(p=>p.Name, "NEST"))
+						.NoMatchFilter(NoMatchShortcut.None)
+					)
+				);
+				
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"{
+  from: 0,
+  size: 10,
+  filter: {
+    indices: {
+      indices: [
+        ""index1"",
+        ""index2""
+      ],
+      filter: {
+        term: {
+          name: ""NEST""
+        }
+      },
+      no_match_filter: ""none""
+    }
+  }
+}";
+			Assert.True(json.JsonEquals(expected), json);
+		}
+		
+	}
+}

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/IndicesQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/IndicesQueryJson.cs
@@ -67,6 +67,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 			}}";
 			Assert.True(json.JsonEquals(expected), json);
 		}
+
 		[Test]
 		public void IndicesQuery()
 		{
@@ -97,5 +98,35 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 			}}";
 			Assert.True(json.JsonEquals(expected), json);
 		}
+
+		[Test]
+		public void IndicesQueryShortcut()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.From(0)
+				.Size(10)
+				.Query(q => q
+					.Indices(fz => fz
+						.Indices(new[] { "elasticsearchprojects", "people", "randomindex" })
+						.Query(qq => qq.Term(f => f.Name, "elasticsearch.pm"))
+						.NoMatchQuery(NoMatchShortcut.All)
+					)
+				);
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"{ from: 0, size: 10, query : 
+			{  
+				indices: {
+					query: { term : { name : {  value : ""elasticsearch.pm"" }  } },
+					no_match_query: ""all"",
+					indices: [
+						""elasticsearchprojects"",
+						""people"",
+						""randomindex""
+					]
+				}
+			}}";
+			Assert.True(json.JsonEquals(expected), json);
+		}
+
 	}
 }


### PR DESCRIPTION
We were missing the [Indices Filter](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-indices-filter.html) as reported in #1187 

This PR also adds support for `all` and `none` shortcuts on the `no_match_filter` as well as making sure that that the indices json property is written first since the order matters.