### PR TITLE
Fix #1166 failing thrift test

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
@@ -48,10 +48,11 @@ namespace Elasticsearch.Net.Connection.Thrift
 				    var protocol = protocolFactory == null ? new TBinaryProtocol(transport) : protocolFactory.GetProtocol(transport);
 
 					var client = new Rest.Client(protocol);
+					tsocket.ConnectTimeout = this._connectionSettings.PingTimeout.GetValueOrDefault(200);
 					tsocket.Timeout = this._connectionSettings.Timeout;
 					tsocket.TcpClient.SendTimeout = this._connectionSettings.Timeout;
 					tsocket.TcpClient.ReceiveTimeout = this._connectionSettings.Timeout;
-					//tsocket.TcpClient.NoDelay = true;
+					tsocket.TcpClient.NoDelay = true;
 
 					queue.Enqueue(client);
 

--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocket.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocket.cs
@@ -44,7 +44,8 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 			}
 		}
 
-		public TSocket(string host, int port) : this(host, port, 0)
+		public TSocket(string host, int port)
+			: this(host, port, 0)
 		{
 		}
 
@@ -56,6 +57,8 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 
 			InitSocket();
 		}
+
+		public int ConnectTimeout { get; set; }
 
 		public int Timeout
 		{
@@ -118,14 +121,14 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 				InitSocket();
 			}
 
-            
-		    var connectionRequest = client.BeginConnect(host, port, null, null);
-            var connected = connectionRequest.AsyncWaitHandle.WaitOne(timeout);
 
-		    if (!connected)
-		    {
-                throw new TTransportException("Failed to connect");
-		    }
+			var connectionRequest = client.BeginConnect(host, port, null, null);
+			var connected = connectionRequest.AsyncWaitHandle.WaitOne(this.ConnectTimeout);
+
+			if (!connected)
+			{
+				throw new TTransportException("Failed to connect");
+			}
 
 			inputStream = client.GetStream();
 			outputStream = client.GetStream();


### PR DESCRIPTION
 because it used the request timeout for connect timeout, transport will kill coordinated requests if the total running time takes longer then the specified timeout as introduced here:

https://github.com/elasticsearch/elasticsearch-net/pull/1093