### PR TITLE
Use ConnectTimeout instead of PingTimeout for thrift connections

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/ThriftConnection.cs
@@ -246,7 +246,7 @@ namespace Elasticsearch.Net.Connection.Thrift
 			var protocol = _protocolFactory == null ? new TBinaryProtocol(transport) : _protocolFactory.GetProtocol(transport);
 
 			var client = new Rest.Client(protocol);
-			tsocket.ConnectTimeout = this._connectionSettings.PingTimeout.GetValueOrDefault(200);
+			tsocket.ConnectTimeout = this._connectionSettings.ConnectTimeout.GetValueOrDefault(200);
 			tsocket.Timeout = this._connectionSettings.Timeout;
 			tsocket.TcpClient.SendTimeout = this._connectionSettings.Timeout;
 			tsocket.TcpClient.ReceiveTimeout = this._connectionSettings.Timeout;

--- a/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
@@ -53,7 +53,10 @@ namespace Elasticsearch.Net.Connection
 		int IConnectionConfigurationValues.Timeout { get { return _timeout; }}
 		
 		private int? _pingTimeout;
-		int? IConnectionConfigurationValues.PingTimeout { get{ return _pingTimeout; } }
+		int? IConnectionConfigurationValues.PingTimeout { get { return _pingTimeout; } }
+
+		private int? _connectTimeout;
+		int? IConnectionConfigurationValues.ConnectTimeout { get { return _connectTimeout; } }
 
 		private int? _deadTimeout;
 		int? IConnectionConfigurationValues.DeadTimeout { get{ return _deadTimeout; } }
@@ -240,8 +243,8 @@ namespace Elasticsearch.Net.Connection
 		}
 
 		/// <summary>
-		/// Timeout in milliseconds when the .NET webrequest should abort the request, note that you can set this to a high value here,
-		/// and specify the timeout in various calls on Elasticsearch's side.
+		/// Sets the default timeout in milliseconds for each request to Elasticsearch.
+		/// NOTE: You can set this to a high value here, and specify the timeout on Elasticsearch's side.
 		/// </summary>
 		/// <param name="timeout">time out in milliseconds</param>
 		public T SetTimeout(int timeout)
@@ -251,13 +254,23 @@ namespace Elasticsearch.Net.Connection
 		}
 
 		/// <summary>
-		/// This is a separate timeout for Ping() requests. A ping should fail as fast as possible.
+		/// Sets the default ping timeout in milliseconds for ping requests, which are used
+		/// to determine whether a node is alive. Pings should fail as fast as possible.
 		/// </summary>
-		/// <param name="timeout">The ping timeout in milliseconds defaults to 200</param>
+		/// <param name="timeout">The ping timeout in milliseconds defaults to 1000, or 2000 is using SSL.</param>
 		public T SetPingTimeout(int timeout)
 		{
 			this._pingTimeout = timeout;
 			return (T) this;
+		}
+
+		/// <summary>
+		/// Sets the default connection timeout in milliseconds.
+		/// </summary>
+		public T SetConnectTimeout(int timeout)
+		{
+			this._connectTimeout = timeout;
+			return (T)this;
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
@@ -23,14 +23,19 @@ namespace Elasticsearch.Net.Connection
 		int MaximumAsyncConnections { get; }
 		
 		/// <summary>
-		/// The time out for calls to elasticsearch
+		/// The timeout in milliseconds for each request to Elasticsearch
 		/// </summary>
 		int Timeout { get; }
 
 		/// <summary>
-		/// The timeout in milliseconds to use for ping calls that are issues to check whether a node is up or not.
+		/// The timeout in milliseconds to use for ping requests, which are issued to determine whether a node is alive
 		/// </summary>
 		int? PingTimeout { get; }
+
+		/// <summary>
+		/// The connect timeout in milliseconds
+		/// </summary>
+		int? ConnectTimeout { get; }
 		
 		/// <summary>
 		/// The time to put dead nodes out of rotation (this will be multiplied by the number of times they've been dead)
@@ -41,20 +46,20 @@ namespace Elasticsearch.Net.Connection
 		/// The maximum ammount of time a node is allowed to marked dead
 		/// </summary>
 		int? MaxDeadTimeout { get; }
-		
+
+		/// <summary>
+		/// Limits the total runtime including retries separately from <see cref="Timeout"/>
+		/// <pre>
+		/// When not specified defaults to <see cref="Timeout"/> which itself defaults to 60 seconds
+		/// </pre>
+		/// </summary>
+		TimeSpan? MaxRetryTimeout { get; }
+
 		/// <summary>
 		/// When a retryable exception occurs or status code is returned this controls the maximum
 		/// amount of times we should retry the call to elasticsearch
 		/// </summary>
 		int? MaxRetries { get; }
-
-		/// <summary>
-		/// Limits the total runtime including retries separately from <see cref="Timeout"/>
-		/// <pre>
-		/// When not specified defaults to <see cref="Timeout"/> which itself defaults to 60seconds
-		/// </pre>
-		/// </summary>
-		TimeSpan? MaxRetryTimeout { get; }
 
 		/// <summary>
 		/// This signals that we do not want to send initial pings to unknown/previously dead nodes


### PR DESCRIPTION
Which required adding `ConnectTimeout` to `ConnectionSettings`.  Now the timeout options are a bit more consistent between `ConnectionSettings` and `RequestConfiguration`.

Also cleaned up the xmldocs a bit.