### PR TITLE
Expose constructor with inner aggregation dictionary

### DIFF
--- a/src/Nest/Domain/Aggregations/BucketAggregationBase.cs
+++ b/src/Nest/Domain/Aggregations/BucketAggregationBase.cs
@@ -1,7 +1,9 @@
-﻿namespace Nest
+﻿using System.Collections.Generic;
+namespace Nest
 {
 	public abstract class BucketAggregationBase : AggregationsHelper , IBucketAggregation
 	{
-		
+		protected BucketAggregationBase() { }
+		protected BucketAggregationBase(IDictionary<string, IAggregation> aggregations) : base(aggregations) { }
 	}
 }

--- a/src/Nest/Domain/Aggregations/SingleBucket.cs
+++ b/src/Nest/Domain/Aggregations/SingleBucket.cs
@@ -1,9 +1,14 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Nest
 {
 	public class SingleBucket : BucketAggregationBase
 	{
+		public SingleBucket() { }
+
+		public SingleBucket(IDictionary<string, IAggregation> aggregations) : base(aggregations) { }
+
 		[JsonProperty("doc_count")]
 		public long DocCount { get; set; }
 	}

--- a/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
+++ b/src/Tests/Nest.Tests.Unit/Nest.Tests.Unit.csproj
@@ -418,6 +418,7 @@
     <Compile Include="Reproduce\Reproduce876Tests.cs" />
     <Compile Include="Reproduce\Reproduce926Tests.cs" />
     <Compile Include="Search\Aggregations\ScriptedMetricJson.cs" />
+    <Compile Include="Search\Aggregations\SingleBucketAggregationTests.cs" />
     <Compile Include="Search\Failures\ShardFailureTests.cs" />
     <Compile Include="Search\Fields\FieldsTests.cs" />
     <Compile Include="Search\Filter\Modes\ConditionlessFilterJson.cs" />

--- a/src/Tests/Nest.Tests.Unit/Search/Aggregations/SingleBucketAggregationTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Aggregations/SingleBucketAggregationTests.cs
@@ -1,0 +1,26 @@
+﻿using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+
+namespace Nest.Tests.Unit.Search.Aggregations
+{
+    [TestFixture]
+    public class SingleBucketAggregationTests
+    {
+        [Test]
+        public void CanSetInnerAggregationsInConstructor()
+        {
+            var bucket = new SingleBucket(new Dictionary<string, IAggregation> { 
+                {"some_agg", new KeyItem { Key = "agg_key", DocCount = 123 }}
+            });
+
+            bucket.Aggregations.Should().ContainKey("some_agg");
+
+            var item = (KeyItem) bucket.Aggregations["some_agg"];
+            item.DocCount.Should().Be(123);
+            item.Key.Should().Be("agg_key");
+
+        }
+    }
+}


### PR DESCRIPTION
When I want to test a function that converts aggregation results into something else I need to set the inner aggregations of a `SingleBucket` in order to set up the test data. This class however doesn't currently expose the constructors of its base classes so it's not possible.