### PR TITLE
Fix/compress body

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
@@ -97,12 +97,10 @@ namespace Elasticsearch.Net.Connection
 		{
 			ThrowIfDisposed();
 
-			var requestTask = DoRequest(method, uri, data, requestSpecificConfig);
-
 			try
 			{
-				requestTask.Wait();
-				return requestTask.Result;
+				return this.DoRequestInternal(method, uri, data, requestSpecificConfig, configureAwait: true)
+					.Result;
 			}
 			catch (AggregateException ex)
 			{
@@ -123,6 +121,12 @@ namespace Elasticsearch.Net.Connection
 		/// <param name="requestSpecificConfig">The request specific configuration.</param>
 		/// <returns>Task&lt;ElasticsearchResponse&lt;Stream&gt;&gt;.</returns>
 		public async Task<ElasticsearchResponse<Stream>> DoRequest(HttpMethod method, Uri uri, byte[] data = null, IRequestConfiguration requestSpecificConfig = null)
+		{
+			return await this.DoRequestInternal(method, uri, data, requestSpecificConfig, configureAwait: false);
+		}
+
+		public async Task<ElasticsearchResponse<Stream>> DoRequestInternal(
+			HttpMethod method, Uri uri, byte[] data = null, IRequestConfiguration requestSpecificConfig = null, bool configureAwait = false)
 		{
 			ThrowIfDisposed();
 
@@ -146,7 +150,10 @@ namespace Elasticsearch.Net.Connection
 						request.Content.Headers.ContentType = new MediaTypeHeaderValue(DefaultContentType);
 				}
 
-				var response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+				HttpResponseMessage response;
+				if (!configureAwait)
+					response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
+				else response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
 
 				if (method == HttpMethod.Head || response.Content == null)
 				{

--- a/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
@@ -58,7 +58,7 @@ namespace Elasticsearch.Net.Connection
 			{
 				Timeout = TimeSpan.FromMilliseconds(_settings.Timeout)
 			};
-			if (settings.EnableCompressedResponses && innerHandler.SupportsAutomaticDecompression)
+			if (settings.EnableCompressedResponses || settings.EnableHttpCompression && innerHandler.SupportsAutomaticDecompression)
 			{
 				innerHandler.AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate;
 				Client.DefaultRequestHeaders.AcceptEncoding.Add(new StringWithQualityHeaderValue("gzip"));

--- a/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
@@ -99,7 +99,7 @@ namespace Elasticsearch.Net.Connection
 
 			try
 			{
-				return this.DoRequestInternal(method, uri, data, requestSpecificConfig, configureAwait: true)
+				return this.DoRequestInternal(method, uri, data, requestSpecificConfig)
 					.Result;
 			}
 			catch (AggregateException ex)
@@ -122,11 +122,11 @@ namespace Elasticsearch.Net.Connection
 		/// <returns>Task&lt;ElasticsearchResponse&lt;Stream&gt;&gt;.</returns>
 		public async Task<ElasticsearchResponse<Stream>> DoRequest(HttpMethod method, Uri uri, byte[] data = null, IRequestConfiguration requestSpecificConfig = null)
 		{
-			return await this.DoRequestInternal(method, uri, data, requestSpecificConfig, configureAwait: false);
+			return await this.DoRequestInternal(method, uri, data, requestSpecificConfig).ConfigureAwait(false);
 		}
 
 		public async Task<ElasticsearchResponse<Stream>> DoRequestInternal(
-			HttpMethod method, Uri uri, byte[] data = null, IRequestConfiguration requestSpecificConfig = null, bool configureAwait = false)
+			HttpMethod method, Uri uri, byte[] data = null, IRequestConfiguration requestSpecificConfig = null)
 		{
 			ThrowIfDisposed();
 
@@ -150,10 +150,8 @@ namespace Elasticsearch.Net.Connection
 						request.Content.Headers.ContentType = new MediaTypeHeaderValue(DefaultContentType);
 				}
 
-				HttpResponseMessage response;
-				if (!configureAwait)
-					response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead);
-				else response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).ConfigureAwait(false);
+				var response = await Client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead)
+					.ConfigureAwait(false);
 
 				if (method == HttpMethod.Head || response.Content == null)
 				{

--- a/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
@@ -110,8 +110,11 @@ namespace Elasticsearch.Net.Connection
 		private TimeSpan? _sniffLifeSpan;
 		TimeSpan? IConnectionConfigurationValues.SniffInformationLifeSpan { get{ return _sniffLifeSpan; } }
 
-		private bool _compressionEnabled;
-		bool IConnectionConfigurationValues.EnableCompressedResponses { get{ return _compressionEnabled; } }
+		private bool _enableCompressedResponses;
+		bool IConnectionConfigurationValues.EnableCompressedResponses { get{ return _enableCompressedResponses; } }
+
+		private bool _enableHttpCompression;
+		bool IConnectionConfigurationValues.EnableHttpCompression { get{ return _enableHttpCompression; } }
 
 		private bool _traceEnabled;
 		bool IConnectionConfigurationValues.TraceEnabled { get{ return _traceEnabled; } }
@@ -176,9 +179,20 @@ namespace Elasticsearch.Net.Connection
 		/// Enable compressed responses from elasticsearch (NOTE that that nodes need to be configured to allow this)
 		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html
 		/// </summary>
+		[Obsolete("Scheduled to be removed in 2.0, please use EnableHttpCompression")]
 		public T EnableCompressedResponses(bool enabled = true)
 		{
-			this._compressionEnabled = enabled;
+			this._enableCompressedResponses = enabled;
+			return (T) this;
+		}
+
+		/// <summary>
+		/// Enable gzip compressed requests and responses, do note that you need to configure elasticsearch to set this
+		/// <see cref="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html"/>
+		/// </summary>
+		public T EnableHttpCompression(bool enabled = true)
+		{
+			this._enableHttpCompression = enabled;
 			return (T) this;
 		}
 

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
@@ -65,7 +65,14 @@ namespace Elasticsearch.Net.Connection
 		/// <summary>
 		/// When set signals elasticsearch to respond with compressed responses
 		/// </summary>
+		[Obsolete("Scheduled to be removed in 2.0, please use EnableHttpCompression")]
 		bool EnableCompressedResponses { get; }
+
+		/// <summary>
+		/// Enable gzip compressed requests and responses, do note that you need to configure elasticsearch to set this
+		/// <see cref="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html"/>
+		/// </summary>
+		bool EnableHttpCompression { get; }
 		
 		/// <summary>
 		/// When set will force all connections through this proxy

--- a/src/Tests/Elasticsearch.Net.Integration.Yaml/YamlTestsBase.cs
+++ b/src/Tests/Elasticsearch.Net.Integration.Yaml/YamlTestsBase.cs
@@ -31,8 +31,6 @@ namespace Elasticsearch.Net.Integration.Yaml
 			var uri = new Uri("http://"+host+":9200/");
 			var settings = new ConnectionConfiguration(uri).ExposeRawResponse();
 
-			var jsonNetSerializer = new ElasticsearchJsonNetSerializer();
-
 			_client = new ElasticsearchClient(settings);
 			//_client = new ElasticsearchClient(settings, serializer: jsonNetSerializer);
 			var infoResponse = _client.Info();

--- a/src/Tests/Nest.Tests.Integration/Core/AsyncTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Core/AsyncTests.cs
@@ -8,17 +8,14 @@ namespace Nest.Tests.Integration.Core
 	{
 
 		[Test]
-		public void TestIndex()
+		public async void TestIndex()
 		{
 			var newProject = new ElasticsearchProject
 			{
 				Name = "COBOLES", //COBOL ES client ?
 			};
-			var t = this.Client.IndexAsync<ElasticsearchProject>(newProject);
-			t.Wait();
-			Assert.True(t.Result.IsValid);
-			Assert.True(t.IsCompleted, "task did not complete");
-			Assert.True(t.IsCompleted, "task did not complete");
+			var t = await  this.Client.IndexAsync<ElasticsearchProject>(newProject);
+			Assert.True(t.IsValid);
 		}
 		
 	}


### PR DESCRIPTION
This PR also allows you to send gzip'd requests, not just receive them. 

When first implementing this I could swear this was not supported (also some information online that indicates its not) but it is at least from Elasticsearch 1.0 to also send gzip'ed data. 