### PR TITLE
Floating weights on function score query / functions

### DIFF
--- a/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
@@ -91,6 +91,7 @@ namespace Nest
 			set { Self.WeightAsDouble = value; }
 		}
 
+		// TODO: Remove in 2.0 and change Weight to double
 		double? IFunctionScoreQuery.WeightAsDouble { get; set; }
 
 		bool IQuery.IsConditionless

--- a/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
+++ b/src/Nest/DSL/Query/FunctionScoreQueryDescriptor.cs
@@ -36,8 +36,10 @@ namespace Nest
 		[JsonProperty(PropertyName = "script_score")]
 		IScriptFilter ScriptScore { get; set; }
 
-		[JsonProperty(PropertyName = "weight")]
 		long? Weight { get; set; }
+
+		[JsonProperty(PropertyName = "weight")]
+		double? WeightAsDouble { get; set; }
 	}
 
 	public class FunctionScoreQuery : PlainQuery, IFunctionScoreQuery
@@ -55,11 +57,20 @@ namespace Nest
 		public float? MaxBoost { get; set; }
 		public IRandomScoreFunction RandomScore { get; set; }
 		public IScriptFilter ScriptScore { get; set; }
-		public long? Weight { get; set; }
+
+		public long? Weight
+		{
+			get { return Convert.ToInt64(this.WeightAsDouble ); }
+			set { this.WeightAsDouble = value; }
+		}
+
+		public double? WeightAsDouble { get; set; }
 	}
 
 	public class FunctionScoreQueryDescriptor<T> : IFunctionScoreQuery where T : class
 	{
+		private IFunctionScoreQuery Self { get { return this; }}
+
 		IEnumerable<IFunctionScoreFunction> IFunctionScoreQuery.Functions { get; set; }
 
 		IQueryContainer IFunctionScoreQuery.Query { get; set; }
@@ -74,16 +85,22 @@ namespace Nest
 
 		IScriptFilter IFunctionScoreQuery.ScriptScore { get; set; }
 		
-		long? IFunctionScoreQuery.Weight { get; set; }
+		long? IFunctionScoreQuery.Weight 
+		{
+			get { return Convert.ToInt64(Self.WeightAsDouble ); }
+			set { Self.WeightAsDouble = value; }
+		}
+
+		double? IFunctionScoreQuery.WeightAsDouble { get; set; }
 
 		bool IQuery.IsConditionless
 		{
 			get
 			{
-				return (((IFunctionScoreQuery)this).Query == null || ((IFunctionScoreQuery)this).Query.IsConditionless) 
-					&& ((IFunctionScoreQuery)this).RandomScore == null 
-					&& ((IFunctionScoreQuery)this).ScriptScore == null 
-					&& !((IFunctionScoreQuery)this).Functions.HasAny();
+				return (Self.Query == null || Self.Query.IsConditionless)
+					&& Self.RandomScore == null 
+					&& Self.ScriptScore == null 
+					&& !Self.Functions.HasAny();
 			}
 		}
 
@@ -92,7 +109,7 @@ namespace Nest
 			querySelector.ThrowIfNull("querySelector");
 			var query = new QueryDescriptor<T>();
 			var q = querySelector(query);
-			((IFunctionScoreQuery)this).Query = q.IsConditionless ? null :q;
+			Self.Query = q.IsConditionless ? null :q;
 			return this;
 		}
 
@@ -105,35 +122,35 @@ namespace Nest
 				f(descriptor);
 			}
 
-			((IFunctionScoreQuery)this).Functions = descriptor;
+			Self.Functions = descriptor;
 
 			return this;
 		}
 
 		public FunctionScoreQueryDescriptor<T> ScoreMode(FunctionScoreMode mode)
 		{
-			((IFunctionScoreQuery)this).ScoreMode = mode;
+			Self.ScoreMode = mode;
 			return this;
 		}
 
 		public FunctionScoreQueryDescriptor<T> BoostMode(FunctionBoostMode mode)
 		{
-			((IFunctionScoreQuery)this).BoostMode = mode;
+			Self.BoostMode = mode;
 			return this;
 		}
 
 		public FunctionScoreQueryDescriptor<T> MaxBoost(float maxBoost)
 		{
-			((IFunctionScoreQuery)this).MaxBoost = maxBoost;
+			Self.MaxBoost = maxBoost;
 			return this;
 		}
 
 		public FunctionScoreQueryDescriptor<T> RandomScore(int? seed = null)
 		{
-			((IFunctionScoreQuery)this).RandomScore = new RandomScoreFunction();
+			Self.RandomScore = new RandomScoreFunction();
 			if (seed.HasValue)
 			{
-				((IFunctionScoreQuery)this).RandomScore.Seed = seed.Value;
+				Self.RandomScore.Seed = seed.Value;
 			}
 			return this;
 		}
@@ -144,14 +161,19 @@ namespace Nest
 			if (scriptSelector != null)
 				scriptSelector(descriptor);
 
-			((IFunctionScoreQuery)this).ScriptScore = descriptor;
+			Self.ScriptScore = descriptor;
 
 			return this;
 		}
 
+		public FunctionScoreQueryDescriptor<T> Weight(double weight)
+		{
+			Self.WeightAsDouble = weight;
+			return this;
+		}
 		public FunctionScoreQueryDescriptor<T> Weight(long weight)
 		{
-			((IFunctionScoreQuery)this).Weight = weight;
+			Self.Weight = weight;
 			return this;
 		}
 	}

--- a/src/Nest/DSL/Query/Functions/IFunctionScoreFunction.cs
+++ b/src/Nest/DSL/Query/Functions/IFunctionScoreFunction.cs
@@ -10,6 +10,12 @@ namespace Nest
 	{
 		FilterContainer Filter { get; set; }
 		long? Weight { get; set; }
+
+		/// <summary>
+		/// This property is added for backwards compatibility reasons and will most likely
+		/// be renamed to Weight when we release NEST 2.0
+		/// </summary>
+		double? WeightAsDouble { get; set; }
 	}
 	
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
@@ -21,8 +27,14 @@ namespace Nest
 		[JsonProperty("filter")]
 		FilterContainer IFunctionScoreFunction.Filter { get; set; }
 
+		long? IFunctionScoreFunction.Weight
+		{
+			get { return Convert.ToInt64(Self.WeightAsDouble); }
+			set { Self.WeightAsDouble = value; }
+		}
+
 		[JsonProperty("weight")]
-		long? IFunctionScoreFunction.Weight { get; set; }
+		double? IFunctionScoreFunction.WeightAsDouble { get; set; }
 
 		public FunctionScoreFunction<T> Filter(Func<FilterDescriptor<T>, FilterContainer> filterSelector)
 		{
@@ -31,6 +43,12 @@ namespace Nest
 			var f = filterSelector(filter);
 
 			this.Self.Filter = f;
+			return this;
+		}
+
+		public FunctionScoreFunction<T> Weight(double weight)
+		{
+			this.Self.WeightAsDouble = weight;
 			return this;
 		}
 

--- a/src/Tests/Nest.Tests.Unit/Search/Query/Singles/FunctionScoreQueryJson.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Query/Singles/FunctionScoreQueryJson.cs
@@ -64,7 +64,7 @@ namespace Nest.Tests.Unit.Search.Query.Singles
 				query : {
                     function_score : { 		
 						query : { match_all : {} },
-						weight : 2
+						weight : 2.0
 					}
 				}
 			}";

--- a/src/Tests/Nest.Tests.Unit/Search/Sorting/FunctionScoreTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Sorting/FunctionScoreTests.cs
@@ -94,7 +94,7 @@ namespace Nest.Tests.Unit.Search.Sorting
                                             ""term1"":""termValue""
                                         }
                                     },
-									weight: 5
+									weight: 5.0
                                 }
                               ]
                             }
@@ -280,7 +280,7 @@ namespace Nest.Tests.Unit.Search.Sorting
 										  ""term1"": ""termValue""
 										}
 									  },
-									 ""weight"": 5
+									 ""weight"": 5.0
 									}
 								  ]
 								}

--- a/src/Tests/Nest.Tests.Unit/Search/Sorting/FunctionScoreTests.cs
+++ b/src/Tests/Nest.Tests.Unit/Search/Sorting/FunctionScoreTests.cs
@@ -1,4 +1,6 @@
-﻿using Nest.Tests.MockData.Domain;
+﻿using System.Collections.Generic;
+using Nest.Resolvers;
+using Nest.Tests.MockData.Domain;
 using NUnit.Framework;
 
 namespace Nest.Tests.Unit.Search.Sorting
@@ -105,17 +107,21 @@ namespace Nest.Tests.Unit.Search.Sorting
 		[Test]
 		public void TestBoostFactor()
 		{
-			var s = new SearchDescriptor<ElasticsearchProject>().Query(
-				q => q.FunctionScore(
-					fs => fs.Functions(
-						f => f.BoostFactor(2)
-							.Filter(
-								filter => filter.Term("term1", "termValue")
-							)
-							.Weight(5)
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.Query(q => q
+					.FunctionScore(fs => fs
+						.Weight(2.0)
+						.Functions(
+							f => f
+								.BoostFactor(2)
+								.Filter(
+									filter => filter.Term("term1", "termValue")
+								)
+								.Weight(0.5)
+						)
 					)
-				)
-			);
+					
+				);
 			var json = TestElasticClient.Serialize(s);
 			var expected = @"{
                           query: {
@@ -128,9 +134,10 @@ namespace Nest.Tests.Unit.Search.Sorting
                                             ""term1"":""termValue""
                                         }
                                     },
-									weight: 5
+                                    weight: 0.5
                                 }
-                              ]
+                              ],
+                              weight: 2.0
                             }
                           }
                         }";
@@ -138,6 +145,112 @@ namespace Nest.Tests.Unit.Search.Sorting
 			Assert.True(json.JsonEquals(expected), json);
 		}
 
+		[Test]
+		public void TestBoostFactor_WrongOverload()
+		{
+			var s = new SearchDescriptor<ElasticsearchProject>()
+				.Query(q => q
+					.FunctionScore(fs => fs
+						.Weight(3)
+						.Functions(
+							f => f
+								.BoostFactor(2)
+								.Filter(
+									filter => filter.Term("term1", "termValue")
+								)
+								.Weight(2)
+						)
+					)
+					
+				);
+			var json = TestElasticClient.Serialize(s);
+			var expected = @"{
+                          query: {
+                            function_score: {
+                              functions : [
+                                {
+                                    boost_factor: 2.0,
+                                    filter:{
+                                        term : {
+                                            ""term1"":""termValue""
+                                        }
+                                    },
+                                    weight: 2.0
+                                }
+                              ],
+                              weight: 3.0
+                            }
+                          }
+                        }";
+
+			Assert.True(json.JsonEquals(expected), json);
+		}
+
+		[Test]
+		public void TestBoostFactor_ObjectInitializer()
+		{
+			IFunctionScoreFunction boost = new BoostFactorFunction<ElasticsearchProject>(2);
+			boost.WeightAsDouble = 0.5;
+			boost.Filter = new TermFilter {Field = Property.Path<ElasticsearchProject>(p => p.Name), Value = "termValue"};
+			QueryContainer q = new FunctionScoreQuery()
+			{
+				WeightAsDouble = 1.0,
+				Functions = new[] {boost}
+
+			};
+			var json = TestElasticClient.Serialize(q);
+			var expected = @"{
+                            function_score: {
+                              functions : [
+                                {
+                                    boost_factor: 2.0,
+                                    filter:{
+                                        term : {
+                                            ""name"":""termValue""
+                                        }
+                                    },
+                                    weight: 0.5
+                                }
+                              ],
+                              weight: 1.0
+                            }
+                        }";
+
+			Assert.True(json.JsonEquals(expected), json);
+		}
+
+		[Test]
+		public void TestBoostFactor_ObjectInitializer_WrongProperty()
+		{
+			IFunctionScoreFunction boost = new BoostFactorFunction<ElasticsearchProject>(2);
+			boost.Weight = 1;
+			boost.Filter = new TermFilter {Field = Property.Path<ElasticsearchProject>(p => p.Name), Value = "termValue"};
+			QueryContainer q = new FunctionScoreQuery()
+			{
+				Weight = 4,
+				Functions = new[] {boost}
+
+			};
+			var json = TestElasticClient.Serialize(q);
+			var expected = @"{
+                            function_score: {
+                              functions : [
+                                {
+                                    boost_factor: 2.0,
+                                    filter:{
+                                        term : {
+                                            ""name"":""termValue""
+                                        }
+                                    },
+                                    weight: 1.0
+                                }
+                              ],
+                              weight: 4.0
+                            }
+                        }";
+
+			Assert.True(json.JsonEquals(expected), json);
+		}
 		[Test]
 		public void TestDecayFunction()
 		{


### PR DESCRIPTION
fix #1210 fix #1087 

Both of the previous PR's submitted a sane way to fix this issue but break backward compatibility. 

This PR is a bit of a hack to make sure if you are using the object initializer syntax we don't break your code. 

Fluent syntax remains `.Weight(long|double)`