### PR TITLE
Added support for the Elastic Search Irish language analyzer.

### DIFF
--- a/src/Nest/Domain/Analysis/Analyzers/Language.cs
+++ b/src/Nest/Domain/Analysis/Analyzers/Language.cs
@@ -25,6 +25,7 @@
 		Hindi, 
 		Hungarian, 
 		Indonesian, 
+		Irish, 
 		Italian, 
 		Norwegian, 
 		Persian, 


### PR DESCRIPTION
Elastic Search has support for a built in Irish language analyzer but NEST is missing the enumeration value. 

http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/analysis-lang-analyzer.html#irish-analyzer
