### PR TITLE
Add support for execution in range filter

### DIFF
--- a/src/Nest/DSL/Filter/IFilterContainer.cs
+++ b/src/Nest/DSL/Filter/IFilterContainer.cs
@@ -1,15 +1,15 @@
-﻿using System;
-using System.Collections.Generic;
-using Nest.DSL.Visitor;
+﻿using Nest.DSL.Visitor;
 using Nest.Resolvers.Converters;
 using Nest.Resolvers.Converters.Filters;
 using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 
 namespace Nest
 {
 	[JsonObject(MemberSerialization = MemberSerialization.OptIn)]
 	[JsonConverter(typeof(ReadAsTypeConverter<FilterContainer>))]
-	public interface IFilterContainer 
+	public interface IFilterContainer
 	{
 		[JsonIgnore]
 		string FilterName { get; set; }
@@ -50,9 +50,9 @@ namespace Nest
 		[JsonConverter(typeof(GeoDistanceFilterConverter))]
 		IGeoDistanceFilter GeoDistance { get; set; }
 
-        [JsonProperty(PropertyName = "geohash_cell")]
-        [JsonConverter(typeof(GeoHashCellFilterConverter))]
-        IGeoHashCellFilter GeoHashCell { get; set; }
+		[JsonProperty(PropertyName = "geohash_cell")]
+		[JsonConverter(typeof(GeoHashCellFilterConverter))]
+		IGeoHashCellFilter GeoHashCell { get; set; }
 
 		[JsonProperty(PropertyName = "geo_distance_range")]
 		[JsonConverter(typeof(GeoDistanceRangeFilterConverter))]
@@ -85,7 +85,7 @@ namespace Nest
 		IHasParentFilter HasParent { get; set; }
 
 		[JsonProperty(PropertyName = "range")]
-		[JsonConverter(typeof(FieldNameFilterConverter<RangeFilter>))]
+		[JsonConverter(typeof(RangeFilterConverter<RangeFilter>))]
 		IRangeFilter Range { get; set; }
 
 		[JsonProperty(PropertyName = "prefix")]

--- a/src/Nest/DSL/Filter/RangeFilterDescriptor.cs
+++ b/src/Nest/DSL/Filter/RangeFilterDescriptor.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using Nest.Resolvers.Converters;
+﻿using Nest.Resolvers.Converters;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+using System.Globalization;
 using System.Linq.Expressions;
+using System.Runtime.Serialization;
 
 namespace Nest
 {
@@ -29,6 +29,8 @@ namespace Nest
 
 		[JsonProperty("time_zone")]
 		string TimeZone { get; set; }
+
+		FilterRangeExecutionType? ExecutionType { get; set; }
 	}
 
 	public class RangeFilter : PlainFilter, IRangeFilter
@@ -37,51 +39,62 @@ namespace Nest
 		{
 			container.Range = this;
 		}
+
 		public string GreaterThanOrEqualTo { get; set; }
 		public string LowerThanOrEqualTo { get; set; }
 		public string GreaterThan { get; set; }
 		public string LowerThan { get; set; }
 		public string TimeZone { get; set; }
+		public FilterRangeExecutionType? ExecutionType { get; set; }
 		public PropertyPathMarker Field { get; set; }
 	}
 
 	public class RangeFilterDescriptor<T> : FilterBase, IRangeFilter where T : class
 	{
-		string IRangeFilter.GreaterThanOrEqualTo { get; set;  }
-		
+		string IRangeFilter.GreaterThanOrEqualTo { get; set; }
+
 		string IRangeFilter.LowerThanOrEqualTo { get; set; }
-		
+
 		string IRangeFilter.GreaterThan { get; set; }
-		
+
 		string IRangeFilter.LowerThan { get; set; }
 
 		string IRangeFilter.TimeZone { get; set; }
 
 		PropertyPathMarker IFieldNameFilter.Field { get; set; }
 
-		private IRangeFilter Self { get { return this;  } }
+		FilterRangeExecutionType? IRangeFilter.ExecutionType { get; set; }
+
+		private IRangeFilter Self
+		{
+			get { return this; }
+		}
 
 		bool IFilter.IsConditionless
 		{
 			get
 			{
-				return this.Self.Field.IsConditionless() || 
-				(	this.Self.GreaterThanOrEqualTo.IsNullOrEmpty() 
-					&& this.Self.LowerThanOrEqualTo.IsNullOrEmpty()
-					&& this.Self.LowerThan.IsNullOrEmpty()
-					&& this.Self.GreaterThan.IsNullOrEmpty()
-				);
+				return this.Self.Field.IsConditionless() ||
+				       (this.Self.GreaterThanOrEqualTo.IsNullOrEmpty()
+				        && this.Self.LowerThanOrEqualTo.IsNullOrEmpty()
+				        && this.Self.LowerThan.IsNullOrEmpty()
+				        && this.Self.GreaterThan.IsNullOrEmpty()
+					       );
 			}
 		}
-		
-		public RangeFilterDescriptor<T> OnField(string field)
+
+		public RangeFilterDescriptor<T> OnField(string field, FilterRangeExecutionType? executionType = null)
 		{
 			this.Self.Field = field;
+			this.Self.ExecutionType = executionType;
 			return this;
 		}
-		public RangeFilterDescriptor<T> OnField(Expression<Func<T, object>> objectPath)
+
+		public RangeFilterDescriptor<T> OnField(Expression<Func<T, object>> objectPath,
+			FilterRangeExecutionType? executionType = null)
 		{
 			this.Self.Field = objectPath;
+			this.Self.ExecutionType = executionType;
 			return this;
 		}
 
@@ -90,13 +103,13 @@ namespace Nest
 			this.Self.GreaterThan = from.HasValue ? from.Value.ToString(CultureInfo.InvariantCulture) : null;
 			return this;
 		}
-	
+
 		public RangeFilterDescriptor<T> GreaterOrEquals(long? from)
 		{
 			this.Self.GreaterThanOrEqualTo = from.HasValue ? from.Value.ToString(CultureInfo.InvariantCulture) : null;
 			return this;
 		}
-	
+
 		public RangeFilterDescriptor<T> Lower(long? to)
 		{
 			this.Self.LowerThan = to.HasValue ? to.Value.ToString(CultureInfo.InvariantCulture) : null;
@@ -114,18 +127,19 @@ namespace Nest
 			this.Self.GreaterThan = from.HasValue ? from.Value.ToString(CultureInfo.InvariantCulture) : null;
 			return this;
 		}
-		
+
 		public RangeFilterDescriptor<T> GreaterOrEquals(double? from)
 		{
 			this.Self.GreaterThanOrEqualTo = from.HasValue ? from.Value.ToString(CultureInfo.InvariantCulture) : null;
 			return this;
 		}
-		
+
 		public RangeFilterDescriptor<T> Lower(double? to)
 		{
 			this.Self.LowerThan = to.HasValue ? to.Value.ToString(CultureInfo.InvariantCulture) : null;
 			return this;
 		}
+
 		/// <summary>
 		/// Same as setting to and include_upper to true.
 		/// </summary>
@@ -134,7 +148,6 @@ namespace Nest
 			this.Self.LowerThanOrEqualTo = to.HasValue ? to.Value.ToString(CultureInfo.InvariantCulture) : null;
 			return this;
 		}
-		
 
 		public RangeFilterDescriptor<T> Greater(string from)
 		{
@@ -166,7 +179,7 @@ namespace Nest
 			this.Self.GreaterThan = from.Value.ToString(format, CultureInfo.InvariantCulture);
 			return this;
 		}
-		
+
 		public RangeFilterDescriptor<T> GreaterOrEquals(DateTime? from, string format = "yyyy-MM-dd'T'HH:mm:ss.fff")
 		{
 			if (!from.HasValue) return this;
@@ -187,11 +200,19 @@ namespace Nest
 			this.Self.LowerThanOrEqualTo = to.Value.ToString(format, CultureInfo.InvariantCulture);
 			return this;
 		}
-	
+
 		public RangeFilterDescriptor<T> TimeZone(string timeZone)
 		{
 			this.Self.TimeZone = timeZone;
 			return this;
 		}
+	}
+
+	[JsonConverter(typeof (StringEnumConverter))]
+	public enum FilterRangeExecutionType
+	{
+		[EnumMember(Value = "index")] Index,
+
+		[EnumMember(Value = "fielddata")] FieldData
 	}
 }

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -857,6 +857,7 @@
     <Compile Include="DSL\Filter\IdsFilterDescriptor.cs" />
     <Compile Include="DSL\Filter\ExistsFilterDescriptor.cs" />
     <Compile Include="Resolvers\Converters\CatThreadPoolRecordConverter.cs" />
+    <Compile Include="Resolvers\Converters\RangeFilterConverter.cs" />
     <Compile Include="Resolvers\Converters\GeoHashCellFilterConverter.cs" />
     <Compile Include="Resolvers\Converters\GeoShapeConverterBase.cs" />
     <Compile Include="Resolvers\Converters\GetRepositoryResponseConverter.cs" />

--- a/src/Nest/Resolvers/Converters/RangeFilterConverter.cs
+++ b/src/Nest/Resolvers/Converters/RangeFilterConverter.cs
@@ -1,0 +1,130 @@
+﻿using Nest.Resolvers;
+using Nest.Resolvers.Converters;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Nest
+{
+	public class RangeFilterConverter<T> : JsonConverter
+		where T : class, new()
+	{
+		private readonly ReadAsTypeConverter<T> _reader;
+
+		public RangeFilterConverter()
+		{
+			this._reader = new ReadAsTypeConverter<T>();
+		}
+
+		public override bool CanConvert(Type objectType)
+		{
+			return typeof (IRangeFilter).IsAssignableFrom(objectType);
+		}
+
+		public override bool CanRead
+		{
+			get { return true; }
+		}
+
+		public override bool CanWrite
+		{
+			get { return true; }
+		}
+
+		public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+		{
+			var depth = reader.Depth;
+			if (reader.TokenType != JsonToken.StartObject)
+				return null;
+
+			var r = JObject.Load(reader);
+			var dict = r.Properties().ToDictionary(p => p.Name);
+
+			var name = GetValue<string>("_name", dict);
+			var cache = GetValue<bool?>("_cache", dict);
+			var cacheKey = GetValue<string>("_cacheKey", dict) ?? GetValue<string>("_cache_key", dict);
+			var executionStr = GetValue<string>("execution", dict);
+			FilterRangeExecutionType execution;
+			var foundExecution = Enum.TryParse(executionStr, true, out execution);
+
+			if (dict.Count == 0) return null;
+
+			var remainingProperty = dict.First();
+
+			var filter = this._reader.ReadJson(remainingProperty.Value.First().CreateReader(), objectType, existingValue,
+				serializer);
+			var setter = filter as IRangeFilter;
+			if (setter != null)
+			{
+				setter.Field = remainingProperty.Key;
+				if (foundExecution)
+					setter.ExecutionType = execution;
+			}
+			var f = filter as IFilter;
+			if (f == null) return filter;
+			f.Cache = cache;
+			f.FilterName = name;
+			f.CacheKey = cacheKey;
+			return filter;
+		}
+
+		private static TValue GetValue<TValue>(string name, Dictionary<string, JProperty> dict)
+		{
+			JProperty prop;
+			if (dict.TryGetValue(name, out prop))
+			{
+				dict.Remove(name);
+				return prop.Value.Value<TValue>();
+			}
+			return default(TValue);
+		}
+
+		private static void WriteProperty(JsonWriter writer, IFilter filter, string field, object value)
+		{
+			if ((field.IsNullOrEmpty() || value == null))
+				return;
+			writer.WritePropertyName(field);
+			writer.WriteValue(value);
+		}
+
+		public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+		{
+			var v = value as IRangeFilter;
+			if (v == null) return;
+
+			var fieldName = v.Field;
+			if (fieldName == null)
+				return;
+
+			var contract = serializer.ContractResolver as SettingsContractResolver;
+			if (contract == null)
+				return;
+
+			var field = contract.Infer.PropertyPath(fieldName);
+			if (field.IsNullOrEmpty())
+				return;
+
+			var cache = v.Cache;
+			var cacheKey = v.CacheKey;
+			var name = v.FilterName;
+
+			v.Cache = null;
+			v.CacheKey = null;
+			v.FilterName = null;
+
+			writer.WriteStartObject();
+			{
+				writer.WritePropertyName(field);
+				serializer.Serialize(writer, value);
+				if (v.ExecutionType.HasValue)
+					WriteProperty(writer, v, "execution", v.ExecutionType.Value.GetStringValue());
+				WriteProperty(writer, v, "_cache", cache);
+				WriteProperty(writer, v, "_cache_key", cacheKey);
+				WriteProperty(writer, v, "_name", name);
+			}
+			writer.WriteEndObject();
+		}
+	}
+}

--- a/src/Tests/Nest.Tests.Integration/Search/Filter/RangeFilterTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Search/Filter/RangeFilterTests.cs
@@ -1,8 +1,8 @@
-﻿using System.Linq;
-using Elasticsearch.Net;
-using NUnit.Framework;
+﻿using Elasticsearch.Net;
 using Nest.Tests.MockData;
 using Nest.Tests.MockData.Domain;
+using NUnit.Framework;
+using System.Linq;
 
 namespace Nest.Tests.Integration.Search.Filter
 {
@@ -22,11 +22,10 @@ namespace Nest.Tests.Integration.Search.Filter
 		{
 			_LookFor = NestTestData.Session.Single<ElasticsearchProject>().Get();
 			_LookFor.Name = "mmm";
-			var status = this.Client.Index(_LookFor, i=>i.Refresh()).ConnectionStatus;
+			_LookFor.LOC = 9;
+			var status = this.Client.Index(_LookFor, i => i.Refresh()).ConnectionStatus;
 			Assert.True(status.Success, status.ResponseRaw.Utf8String());
 		}
-
-
 
 		/// <summary>
 		/// Set of filters that should not filter de documento _LookFor.
@@ -61,7 +60,23 @@ namespace Nest.Tests.Integration.Search.Filter
 			this.DoFilterTest(f => f.Range(range => range.OnField(e => e.Name).GreaterOrEquals(name)), _LookFor, true);
 
 			this.DoFilterTest(f => f.Range(range => range.OnField(e => e.Name).LowerOrEquals(name)), _LookFor, true);
+		}
 
+		/// <summary>
+		/// Set of filters that should filter de documento _LookFor.
+		/// </summary>
+		[Test]
+		public void TestNumericFiltered()
+		{
+			var name = _LookFor.Id;
+
+			this.DoFilterTest(
+				f => f.Range(range => range.OnField(e => e.LOC, FilterRangeExecutionType.FieldData).GreaterOrEquals(2)), _LookFor,
+				true);
+
+			this.DoFilterTest(
+				f => f.Range(range => range.OnField(e => e.LOC, FilterRangeExecutionType.FieldData).Lower(2)), _LookFor,
+				false);
 		}
 	}
 }

--- a/src/Tests/Nest.Tests.Unit/QueryParsers/Filter/RangeFilterTests.cs
+++ b/src/Tests/Nest.Tests.Unit/QueryParsers/Filter/RangeFilterTests.cs
@@ -1,21 +1,21 @@
-using System;
-using System.Globalization;
 using FluentAssertions;
 using NUnit.Framework;
+using System;
+using System.Globalization;
 
 namespace Nest.Tests.Unit.QueryParsers.Filter
 {
 	[TestFixture]
-	public class RangeFilterTests : ParseFilterTestsBase 
+	public class RangeFilterTests : ParseFilterTestsBase
 	{
 		[Test]
 		[TestCase("cacheName", "cacheKey", true)]
 		public void Range_Deserializes(string cacheName, string cacheKey, bool cache)
 		{
-			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache, 
-				f=>f.Range,
-				f=>f.Range(n => n
-					.OnField(p=>p.LOC)
+			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache,
+				f => f.Range,
+				f => f.Range(n => n
+					.OnField(p => p.LOC)
 					.GreaterOrEquals("10")
 					.LowerOrEquals("20")
 					)
@@ -24,17 +24,16 @@ namespace Nest.Tests.Unit.QueryParsers.Filter
 			rangeFilter.Field.Should().Be("loc");
 			rangeFilter.LowerThanOrEqualTo.Should().Be("20");
 			rangeFilter.GreaterThanOrEqualTo.Should().Be("10");
-
 		}
 
 		[Test]
 		[TestCase("cacheName", "cacheKey", true)]
 		public void Range_Long_Deserializes(string cacheName, string cacheKey, bool cache)
 		{
-			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache, 
-				f=>f.Range,
-				f=>f.Range(n => n
-					.OnField(p=>p.LOC)
+			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache,
+				f => f.Range,
+				f => f.Range(n => n
+					.OnField(p => p.LOC, FilterRangeExecutionType.FieldData)
 					.GreaterOrEquals(10)
 					.LowerOrEquals(20)
 					)
@@ -42,34 +41,37 @@ namespace Nest.Tests.Unit.QueryParsers.Filter
 
 			rangeFilter.GreaterThanOrEqualTo.Should().Be("10");
 			rangeFilter.LowerThanOrEqualTo.Should().Be("20");
+			rangeFilter.ExecutionType.Should().Be(FilterRangeExecutionType.FieldData);
 		}
-		
+
 		[Test]
 		[TestCase("cacheName", "cacheKey", true)]
 		public void Range_DateTime_Deserializes(string cacheName, string cacheKey, bool cache)
 		{
 			var dateFrom = DateTime.UtcNow.AddDays(-1);
 			var dateTo = DateTime.UtcNow.AddDays(1);
-			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache, 
-				f=>f.Range,
-				f=>f.Range(n => n
-					.OnField(p=>p.LOC)
+			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache,
+				f => f.Range,
+				f => f.Range(n => n
+					.OnField(p => p.LOC)
 					.GreaterOrEquals(dateFrom)
 					.LowerOrEquals(dateTo)
 					)
 				);
-			rangeFilter.GreaterThanOrEqualTo.Should().Be(dateFrom.ToString("yyyy-MM-dd'T'HH:mm:ss.fff", CultureInfo.InvariantCulture));
-			rangeFilter.LowerThanOrEqualTo.Should().Be(dateTo.ToString("yyyy-MM-dd'T'HH:mm:ss.fff", CultureInfo.InvariantCulture));
+			rangeFilter.GreaterThanOrEqualTo.Should()
+				.Be(dateFrom.ToString("yyyy-MM-dd'T'HH:mm:ss.fff", CultureInfo.InvariantCulture));
+			rangeFilter.LowerThanOrEqualTo.Should()
+				.Be(dateTo.ToString("yyyy-MM-dd'T'HH:mm:ss.fff", CultureInfo.InvariantCulture));
 		}
-		
+
 		[Test]
 		[TestCase("cacheName", "cacheKey", true)]
 		public void Range_Double_Deserializes(string cacheName, string cacheKey, bool cache)
 		{
-			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache, 
-				f=>f.Range,
-				f=>f.Range(n => n
-					.OnField(p=>p.LOC)
+			var rangeFilter = this.SerializeThenDeserialize(cacheName, cacheKey, cache,
+				f => f.Range,
+				f => f.Range(n => n
+					.OnField(p => p.LOC)
 					.GreaterOrEquals(20.1)
 					.LowerOrEquals(20.22)
 					)
@@ -77,6 +79,5 @@ namespace Nest.Tests.Unit.QueryParsers.Filter
 			rangeFilter.GreaterThanOrEqualTo.Should().Be("20.1");
 			rangeFilter.LowerThanOrEqualTo.Should().Be("20.22");
 		}
-
 	}
 }


### PR DESCRIPTION
The numeric range was deprecated and replaced with range filter with fielddata execution:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-range-filter.html#_execution