### PR TITLE
fix #1251 Smarter untyped baseindextypepath

### DIFF
--- a/src/Nest/DSL/Paths/IndexTypePathDescriptor.cs
+++ b/src/Nest/DSL/Paths/IndexTypePathDescriptor.cs
@@ -24,13 +24,18 @@ namespace Nest
 			var inferrer = new ElasticInferrer(settings);
 
 			if (path.Index == null)
-				throw new DslException("Index() not specified");
+			{
+				if (path.Type != null && path.Type.Type != null)
+					path.Index = path.Type.Type;
+				else 
+					throw new DslException("Index() not specified");
+			}
 			
 			if (path.Type == null)
 				throw new DslException("Type() not specified");
 
 			var index = inferrer.IndexName(path.Index); 
-			var type = inferrer.TypeName(path.Type); 
+			var type = inferrer.TypeName(path.Type);
 
 			pathInfo.Index = index;
 			pathInfo.Type = type;
@@ -50,6 +55,7 @@ namespace Nest
 
 			if (path.Type == null)
 				path.Type = inferrer.TypeName<T>();
+
 
 			var index = inferrer.IndexName(path.Index);
 			var type = inferrer.TypeName(path.Type);

--- a/src/Tests/Nest.Tests.Unit/BigBadUrlUnitTests.cs
+++ b/src/Tests/Nest.Tests.Unit/BigBadUrlUnitTests.cs
@@ -111,6 +111,7 @@ namespace Nest.Tests.Unit.Cluster
 			Do("HEAD", "/mydefaultindex", c => c.IndexExists(h => h.Index<Doc>()));
 			Do("HEAD", "/mydefaultindex/_alias/myalias", c => c.AliasExists(h => h.Index<Doc>().Name("myalias")));
 			Do("HEAD", "/mydefaultindex/some-type", c => c.TypeExists(h => h.Index<Doc>().Type("some-type")));
+			Do("HEAD", "/mydefaultindex/doc", c => c.TypeExists(h=>h.Type<Doc>()));
 			Do("HEAD", "/_alias/myalias", c => c.AliasExists(new AliasExistsRequest("myalias")));
 			Do("POST", "/_bulk", c => c.IndexMany(Enumerable.Range(0, 10).Select(i => new Doc {Id = i.ToString()})));
 			Do("POST", "/customindex/customtype/_bulk", c =>


### PR DESCRIPTION
on untyped IndexTypePaths steal the type's type information and use it to infer index as well if no index has been explicitly set.