### PR TITLE
Adding collect_mode to terms aggretation descriptor

### DIFF
--- a/src/Nest/DSL/Aggregations/TermsAggregationDescriptor.cs
+++ b/src/Nest/DSL/Aggregations/TermsAggregationDescriptor.cs
@@ -39,6 +39,9 @@ namespace Nest
 
 		[JsonProperty("params")]
 		IDictionary<string, object> Params { get; set; }
+
+		[JsonProperty("collect_mode")]
+		TermsAggregationCollectMode? CollectMode { get; set; }
 	}
 
 	public class TermsAggregator : BucketAggregator, ITermsAggregator
@@ -53,6 +56,7 @@ namespace Nest
 		public TermsIncludeExclude Include { get; set; }
 		public TermsIncludeExclude Exclude { get; set; }
 		public IDictionary<string, object> Params { get; set; }
+		public TermsAggregationCollectMode? CollectMode { get; set; }
 	}
 
 
@@ -80,6 +84,8 @@ namespace Nest
 
 		IDictionary<string, object> ITermsAggregator.Params { get; set; }
 
+		TermsAggregationCollectMode? ITermsAggregator.CollectMode { get; set; }
+		
 		public TermsAggregationDescriptor<T> Field(string field)
 		{
 			Self.Field = field;
@@ -150,6 +156,11 @@ namespace Nest
 		public TermsAggregationDescriptor<T> Exclude(string excludePattern, string regexFlags = null)
 		{
 			Self.Exclude = new TermsIncludeExclude() { Pattern = excludePattern, Flags = regexFlags };
+			return this;
+		}
+		public TermsAggregationDescriptor<T> CollectMode(TermsAggregationCollectMode collectMode)
+		{
+			Self.CollectMode = collectMode;
 			return this;
 		}
 	}

--- a/src/Nest/Enums/TermsAggregationCollectMode.cs
+++ b/src/Nest/Enums/TermsAggregationCollectMode.cs
@@ -1,0 +1,25 @@
+﻿using System.Runtime.Serialization;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+using System;
+
+namespace Nest
+{
+	/// <summary>
+	/// Determines how the terms aggregation is executed
+	/// </summary>
+	[JsonConverter(typeof(StringEnumConverter))]
+	public enum TermsAggregationCollectMode
+	{
+		/// <summary>
+		/// Order by using field values directly in order to aggregate data per-bucket 
+		/// </summary>
+		[EnumMember(Value = "depth_first")]
+		DepthFirst,
+		/// <summary>
+		/// Order by using ordinals of the field values instead of the values themselves
+		/// </summary>
+		[EnumMember(Value = "breadth_first")]
+		BreadthFirst
+	}
+}

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -398,6 +398,7 @@
     <Compile Include="Enums\RangeExecution.cs" />
     <Compile Include="Enums\RoutingAllocationEnableOption.cs" />
     <Compile Include="Enums\ScriptLang.cs" />
+    <Compile Include="Enums\TermsAggregationCollectMode.cs" />
     <Compile Include="Exception\RestoreException.cs" />
     <Compile Include="Exception\SnapshotException.cs" />
     <Compile Include="ExposedInternals\NestSerializer.cs" />

--- a/src/Tests/Nest.Tests.Integration/Aggregations/TermsAggregationTests.cs
+++ b/src/Tests/Nest.Tests.Integration/Aggregations/TermsAggregationTests.cs
@@ -95,5 +95,56 @@ namespace Nest.Tests.Integration.Aggregations
 				}
 			}
 		}
+
+		[Test]
+		public void NestedEmptyAggregationThreeLevelDeepsWithBFS()
+		{
+			var results = this.Client.Search<ElasticsearchProject>(s => s
+				.Size(0)
+				.Aggregations(a => a
+					.Terms("countries", t => t
+						.Field(p => p.Country)
+						.CollectMode(TermsAggregationCollectMode.BreadthFirst)
+						.Aggregations(aa => aa
+							.Terms("noop", tt => tt.Field("noop"))
+							.Terms("names", tt => tt
+								.Field(p => p.Name)
+								.Aggregations(aaa => aaa
+									.Average("avg_loc", avg => avg.Field(p => p.LOC))
+								)
+							)
+						)
+					)
+				)
+			);
+			results.IsValid.Should().BeTrue();
+			var termBucket = results.Aggs.Terms("countries");
+			termBucket.Should().NotBeNull();
+			termBucket.Items.Should().NotBeEmpty()
+				.And.OnlyContain(i => !i.Key.IsNullOrEmpty())
+				.And.OnlyContain(i => i.DocCount > 0);
+
+			foreach (var term in termBucket.Items)
+			{
+				var country = term.Key;
+				country.Should().NotBeNullOrWhiteSpace();
+
+				var noop = term.Terms("noop");
+				noop.Should().NotBeNull();
+				noop.Items.Should().BeEmpty();
+
+				var names = term.Terms("names");
+				names.Should().NotBeNull();
+				names.Items.Should().NotBeEmpty();
+
+				foreach (var nameTerm in names.Items)
+				{
+					var name = nameTerm.Key;
+					var average = nameTerm.Average("avg_loc");
+					average.Should().NotBeNull();
+					average.Value.Should().HaveValue();
+				}
+			}
+		}
 	}
 }


### PR DESCRIPTION
Support for __collect_mode__ in terms aggregation descriptor
---------------------------------------------------
**"collect_mode"** on a terms aggregation specifies, to use either __depth first__ or __breadth first__ evaluation of nested terms aggregations.
In __breadth_first__ mode, Elastic search supports calculation of child aggregation, after the pruning of parent aggregation is done, this can prevent certain combinatorial explosions child aggs can bring in depending on your data mappings and queries.

[Details from Elasticsearch documentation](
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations-bucket-terms-aggregation.html#_collect_mode)
