### PR TITLE
expose SetTcpKeepAlive() on ConnectionSettings 

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.HttpClient/HttpClientConnection.cs
@@ -12,6 +12,7 @@ namespace Elasticsearch.Net.Connection
 	/// <summary>
 	/// IConnection implemented using <see cref="System.Net.Http.HttpClient"/>
 	/// </summary>
+	[Obsolete("The HttpClientConnection uses HttpClient and is not currently fully tested, with Elasticsearch.NET and NEST 2.0 we'll move the default HttpConnection over the HttpClient")]
 	public class HttpClientConnection : IConnection, IDisposable
 	{
 		private readonly IConnectionConfigurationValues _settings;

--- a/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/ConnectionConfiguration.cs
@@ -67,6 +67,12 @@ namespace Elasticsearch.Net.Connection
 		private TimeSpan? _maxRetryTimeout;
 		TimeSpan? IConnectionConfigurationValues.MaxRetryTimeout { get{ return _maxRetryTimeout; } }
 	
+		private int? _keepAliveTime;
+		int? IConnectionConfigurationValues.KeepAliveTime { get{ return _keepAliveTime; } }
+	
+		private int? _keepAliveInterval;
+		int? IConnectionConfigurationValues.KeepAliveInterval { get{ return _keepAliveInterval; } }
+	
 		private string _proxyUsername;
 		string IConnectionConfigurationValues.ProxyUsername { get{ return _proxyUsername; } }
 		
@@ -154,6 +160,13 @@ namespace Elasticsearch.Net.Connection
 		{
 			//this.Host = uri.Host;
 			//this.Port = uri.Port
+		}
+
+		public T EnableTcpKeepAlive(int keepAliveTime, int keepAliveInterval)
+		{
+			this._keepAliveTime = keepAliveTime;
+			this._keepAliveInterval = keepAliveInterval;
+			return (T) this;
 		}
 
 		public T MaximumRetries(int maxRetries)

--- a/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Connection/Configuration/IConnectionConfigurationValues.cs
@@ -162,6 +162,19 @@ namespace Elasticsearch.Net.Connection
 		/// Basic access authorization credentials to specify with all requests.
 		/// </summary>
 		/// TODO: Rename to BasicAuthenticationCredentials in 2.0
-		BasicAuthorizationCredentials BasicAuthorizationCredentials { get; } 
+		BasicAuthorizationCredentials BasicAuthorizationCredentials { get; }
+		
+		/// <summary>
+		/// KeepAliveTime - specifies the timeout, in milliseconds, with no
+        /// activity until the first keep-alive packet is sent. 
+		/// </summary>
+		int? KeepAliveTime { get; }
+
+		/// <summary>
+		/// KeepAliveInterval - specifies the interval, in milliseconds, between
+        /// when successive keep-alive packets are sent if no acknowledgement is
+        /// received. 
+		/// </summary>
+		int? KeepAliveInterval { get; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -148,6 +148,11 @@ namespace Elasticsearch.Net.Connection
 			requestServicePoint.UseNagleAlgorithm = false;
 			requestServicePoint.Expect100Continue = false;
 			requestServicePoint.ConnectionLimit = 10000;
+			//looking at http://referencesource.microsoft.com/#System/net/System/Net/ServicePoint.cs
+			//this method only sets internal values and wont actually cause timers and such to be reset
+			//So it should be idempotent if called with the same parameters
+			if (this.ConnectionSettings.KeepAliveTime.HasValue && this.ConnectionSettings.KeepAliveInterval.HasValue)
+				requestServicePoint.SetTcpKeepAlive(true, this.ConnectionSettings.KeepAliveTime.Value, this.ConnectionSettings.KeepAliveInterval.Value);
 		}
 
 		protected virtual HttpWebRequest CreateHttpWebRequest(Uri uri, string method, byte[] data, IRequestConfiguration requestSpecificConfig)


### PR DESCRIPTION
so you do not need to subclass HttpConnection and override `AlterServicePoint()` to set it.

Sidenote:

I also added an Obsolete on `HttpClientConnection` indicating its not as well tested as `HttpConnection` and as a heads up that with Elasticsearch.NET/NEST 2.0 we'll be moving the default `HttpConnection` over to `HttpClient` anyway. 

Im still not totally sure about moving over to `HttpClient` though, yes its a nicer interface, but there is a real benefit of having a **true** synchronous code path without the overhead of async dispatching even if that happens on IOCP threads. Calling `.Result` on a task is not really equivalent.

We might endup ifdeffing `HttpConnection` specifically for `aspnetcore50`, still lots to research and measure :)
