### PR TITLE
When using SniffOnStartup() and newing clients

### DIFF
--- a/src/Elasticsearch.Net/Connection/Transport.cs
+++ b/src/Elasticsearch.Net/Connection/Transport.cs
@@ -65,8 +65,11 @@ namespace Elasticsearch.Net.Connection
 
 			this._requestHandler = new RequestHandler(this.Settings, this._connectionPool, this.Connection, this._serializer, this._memoryStreamProvider, this);
 			this._requestHandlerAsync = new RequestHandlerAsync(this.Settings, this._connectionPool, this.Connection, this._serializer, this._memoryStreamProvider, this);
-			if (this._connectionPool.AcceptsUpdates && this.Settings.SniffsOnStartup)
+			if (this._connectionPool.AcceptsUpdates && this.Settings.SniffsOnStartup && !this._connectionPool.SniffedOnStartup)
+			{
 				Self.SniffClusterState();
+				this._connectionPool.SniffedOnStartup = true;
+			}
 		}
 
 		/* PING/SNIFF	*** ********************************************/

--- a/src/Elasticsearch.Net/ConnectionPool/IConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/IConnectionPool.cs
@@ -25,6 +25,11 @@ namespace Elasticsearch.Net.ConnectionPool
 		bool UsingSsl { get; }
 
 		/// <summary>
+		/// Bookkeeps wheter this connectionpool has seen a sniff on startup. 
+		/// </summary>
+		bool SniffedOnStartup { get; set; }
+
+		/// <summary>
 		/// Gets the next live Uri to perform the request on
 		/// </summary>
 		/// <param name="initialSeed">pass the original seed when retrying, this guarantees that the nodes are walked in a

--- a/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SingleNodeConnectionPool.cs
@@ -10,8 +10,14 @@ namespace Elasticsearch.Net.ConnectionPool
 		public int MaxRetries { get { return 0;  } }
 
 		public bool AcceptsUpdates { get { return false; } }
-
+		
 		public bool UsingSsl { get { return _uri.Scheme == Uri.UriSchemeHttps; } }
+
+		public bool SniffedOnStartup
+		{
+			get { return false; }
+			set {  }
+		}
 
 		public SingleNodeConnectionPool(Uri uri)
 		{

--- a/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
@@ -22,6 +22,8 @@ namespace Elasticsearch.Net.ConnectionPool
 
 		public bool UsingSsl { get; internal set; }
 
+		public bool SniffedOnStartup { get; set; }
+
 		public StaticConnectionPool(
 			IEnumerable<Uri> uris, 
 			bool randomizeOnStartup = true, 

--- a/src/Nest/Domain/Observers/RestoreObservable.cs
+++ b/src/Nest/Domain/Observers/RestoreObservable.cs
@@ -109,14 +109,16 @@ namespace Nest
 		protected virtual void Dispose(bool disposing)
 		{
 			if (_disposed) return;
+			if (_timer != null) _timer.Dispose();
+			if (_restoreStatusHumbleObject != null)
+			{
+				_restoreStatusHumbleObject.Next -= _nextEventHandlers;
+				_restoreStatusHumbleObject.Completed -= _completedEentHandlers;
+				_restoreStatusHumbleObject.Error -= _errorEventHandlers;
 
-			_timer.Dispose();
-			_restoreStatusHumbleObject.Next -= _nextEventHandlers;
-			_restoreStatusHumbleObject.Completed -= _completedEentHandlers;
-			_restoreStatusHumbleObject.Error -= _errorEventHandlers;
-
-			_restoreStatusHumbleObject.Completed -= StopTimer;
-			_restoreStatusHumbleObject.Error -= StopTimer;
+				_restoreStatusHumbleObject.Completed -= StopTimer;
+				_restoreStatusHumbleObject.Error -= StopTimer;
+			}
 
 			_disposed = true;
 		}

--- a/src/Nest/Domain/Observers/SnapshotObservable.cs
+++ b/src/Nest/Domain/Observers/SnapshotObservable.cs
@@ -109,14 +109,17 @@ namespace Nest
 		{
 			if (_disposed) return;
 
-			_timer.Dispose();
+			if (_timer != null) _timer.Dispose();
 
-			_snapshotStatusHumbleObject.Next -= _nextEventHandler;
-			_snapshotStatusHumbleObject.Completed -= _completedEentHandler;
-			_snapshotStatusHumbleObject.Error -= _errorEventHandler;
+			if (_snapshotStatusHumbleObject != null)
+			{
+				_snapshotStatusHumbleObject.Next -= _nextEventHandler;
+				_snapshotStatusHumbleObject.Completed -= _completedEentHandler;
+				_snapshotStatusHumbleObject.Error -= _errorEventHandler;
 
-			_snapshotStatusHumbleObject.Completed -= StopTimer;
-			_snapshotStatusHumbleObject.Error -= StopTimer;
+				_snapshotStatusHumbleObject.Completed -= StopTimer;
+				_snapshotStatusHumbleObject.Error -= StopTimer;
+			}
 
 			_disposed = true;
 		}

--- a/src/Tests/Elasticsearch.Net.Tests.Unit/ConnectionPools/Sniffing/SniffingConnectionPoolTests.cs
+++ b/src/Tests/Elasticsearch.Net.Tests.Unit/ConnectionPools/Sniffing/SniffingConnectionPoolTests.cs
@@ -57,26 +57,32 @@ namespace Elasticsearch.Net.Tests.Unit.ConnectionPools.Sniffing
 				var pingCall = FakeCalls.PingAtConnectionLevel(fake);
 				pingCall.Returns(FakeResponse.Ok(config));
 				var sniffCall = FakeCalls.Sniff(fake, config, uris);
-				var transport = FakeCalls.ProvideDefaultTransport(fake);
 				var getCall = FakeCalls.GetSyncCall(fake);
 				getCall.Returns(FakeResponse.Ok(config));
 
-				var client1 = new ElasticsearchClient(config, transport: transport);
+				var transport1 = FakeCalls.ProvideRealTranportInstance(fake);
+				var transport2 = FakeCalls.ProvideRealTranportInstance(fake);
+				var transport3 = FakeCalls.ProvideRealTranportInstance(fake);
+				var transport4 = FakeCalls.ProvideRealTranportInstance(fake);
+
+				transport1.Should().NotBe(transport2);
+
+				var client1 = new ElasticsearchClient(config, transport: transport1);
 				client1.Info();
 				client1.Info();
 				client1.Info();
 				client1.Info();
-				var client2 = new ElasticsearchClient(config, transport: transport); 
+				var client2 = new ElasticsearchClient(config, transport: transport2); 
 				client2.Info();
 				client2.Info();
 				client2.Info();
 				client2.Info();
-				var client3 = new ElasticsearchClient(config, transport: transport); 
+				var client3 = new ElasticsearchClient(config, transport: transport3); 
 				client3.Info();
 				client3.Info();
 				client3.Info();
 				client3.Info();
-				var client4 = new ElasticsearchClient(config, transport: transport); 
+				var client4 = new ElasticsearchClient(config, transport: transport4); 
 				client4.Info();
 				client4.Info();
 				client4.Info();


### PR DESCRIPTION
All the time it will resend a sniff on each `new()` :cry: , this fixes that by doing additional bookkeeping on IConnectionpool.

ty @poulfoged for reporting this [on twitter](https://twitter.com/Mpdreamz/status/570590301041123328)