### PR TITLE
Develop - problem with opening thrift connection

### DIFF
--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocket.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocket.cs
@@ -38,7 +38,7 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 		private Exception socketexception;
 		private ManualResetEvent timeoutObject = new ManualResetEvent(false);
 
-		public TcpClient Connect(TcpClient _client)
+		public TcpClient Connect()
 		{
 			timeoutObject.Reset();
 			socketexception = null;
@@ -171,7 +171,7 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 				InitSocket();
 			}
 
-			client = Connect(client);
+			client = Connect();
 
 			inputStream = client.GetStream();
 			outputStream = client.GetStream();

--- a/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocket.cs
+++ b/src/Connections/Elasticsearch.Net.Connection.Thrift/Transport/TSocket.cs
@@ -23,6 +23,7 @@
 
 using System;
 using System.Net.Sockets;
+using System.Threading;
 
 namespace Elasticsearch.Net.Connection.Thrift.Transport
 {
@@ -32,6 +33,55 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 		private readonly int port;
 		private TcpClient client;
 		private int timeout;
+
+		private bool isConnectionSuccessful = false;
+		private Exception socketexception;
+		private ManualResetEvent timeoutObject = new ManualResetEvent(false);
+
+		public TcpClient Connect(TcpClient _client)
+		{
+			timeoutObject.Reset();
+			socketexception = null;
+
+			client.BeginConnect(host, port, new AsyncCallback(CallBackMethod), client);
+
+			if (timeoutObject.WaitOne(timeout, false))
+			{
+				if (isConnectionSuccessful)
+				{
+					return client;
+				}
+
+				throw socketexception ?? new Exception("Socket exception should not be null.");
+			}
+
+			client.Close();
+			throw new TimeoutException("TimeOut Exception");
+		}
+
+		private void CallBackMethod(IAsyncResult asyncresult)
+		{
+			try
+			{
+				isConnectionSuccessful = false;
+				var tcpclient = asyncresult.AsyncState as TcpClient;
+
+				if (tcpclient != null && tcpclient.Client != null)
+				{
+					tcpclient.EndConnect(asyncresult);
+					isConnectionSuccessful = true;
+				}
+			}
+			catch (Exception ex)
+			{
+				isConnectionSuccessful = false;
+				socketexception = ex;
+			}
+			finally
+			{
+				timeoutObject.Set();
+			}
+		}
 
 		public TSocket(TcpClient client)
 		{
@@ -121,14 +171,7 @@ namespace Elasticsearch.Net.Connection.Thrift.Transport
 				InitSocket();
 			}
 
-
-			var connectionRequest = client.BeginConnect(host, port, null, null);
-			var connected = connectionRequest.AsyncWaitHandle.WaitOne(this.ConnectTimeout);
-
-			if (!connected)
-			{
-				throw new TTransportException("Failed to connect");
-			}
+			client = Connect(client);
 
 			inputStream = client.GetStream();
 			outputStream = client.GetStream();


### PR DESCRIPTION
This was happened when a lot of simulating non framed thrift connection try to open. When we rebuild our indexes (worker threads - builds index).

After one testing day, a exception described in issue #1254 didn't raise.